### PR TITLE
Make Dark Shackles a targeted card

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -98,7 +98,7 @@ impl Card {
             | SearingBlow | Rampage | Uppercut | SeverSoul | Carnage | Hemokinesis | Dropkick
             | Pummel | BloodForBlood | RecklessCharge | SpotWeakness | Disarm | Bludgeon | Feed
             | FiendFire | SwiftStrike | FlashOfSteel | MindBlast | Bite | RitualDagger
-            | HandOfGreed | DebugKill => true,
+            | HandOfGreed | DarkShackles | DebugKill => true,
             Blind | Trip => self.upgrade_count == 0,
             _ => false,
         }


### PR DESCRIPTION
Dark Shackles applies its Strength debuff to a chosen enemy, but it was missing from Card::has_target, so it was offered with no target and dark_shackles_behavior panicked unwrapping info.target. Add it to the list of targeted cards.