### PR TITLE
Apply Strength before asserting attack damage is non-negative

### DIFF
--- a/src/cards/attacks.rs
+++ b/src/cards/attacks.rs
@@ -629,7 +629,6 @@ mod tests {
     fn test_heavy_blade_negative_strength() {
         let mut g = GameBuilder::default().build_combat();
         g.energy = 99;
-        // 14 + (-10) * 2 is negative; it should clamp to 0, not panic.
         g.player.set_status(Status::Strength, -10);
         g.monsters[0].creature.cur_hp = 100;
         g.play_card(CardClass::HeavyBlade, Some(CreatureRef::monster(0)));

--- a/src/cards/attacks.rs
+++ b/src/cards/attacks.rs
@@ -626,6 +626,17 @@ mod tests {
     }
 
     #[test]
+    fn test_heavy_blade_negative_strength() {
+        let mut g = GameBuilder::default().build_combat();
+        g.energy = 99;
+        // 14 + (-10) * 2 is negative; it should clamp to 0, not panic.
+        g.player.set_status(Status::Strength, -10);
+        g.monsters[0].creature.cur_hp = 100;
+        g.play_card(CardClass::HeavyBlade, Some(CreatureRef::monster(0)));
+        assert_eq!(g.monsters[0].creature.cur_hp, 100);
+    }
+
+    #[test]
     fn test_anger() {
         let mut g = GameBuilder::default().build_combat();
         g.play_card(CardClass::Anger, Some(CreatureRef::monster(0)));

--- a/src/game.rs
+++ b/src/game.rs
@@ -1050,7 +1050,6 @@ impl Game {
 
     pub fn damage(&mut self, target: CreatureRef, mut amount: i32, ty: DamageType) {
         assert!(self.get_creature(target).is_actionable());
-        assert!(amount >= 0);
         if let DamageType::Attack {
             source,
             on_fatal: _,
@@ -1059,6 +1058,9 @@ impl Game {
             if !self.get_creature(source).is_actionable() {
                 return;
             }
+            // calculate_damage applies Strength etc. and clamps to >= 0, so a
+            // negative pre-calc amount (e.g. Heavy Blade with negative Strength)
+            // is fine here.
             amount = self.calculate_damage(amount, source, target);
             if let Some(a) = self
                 .get_creature(target)
@@ -1075,6 +1077,7 @@ impl Game {
                 self.action_queue.push_top(a);
             }
         }
+        assert!(amount >= 0);
         let c = self.get_creature_mut(target);
         if !c.is_actionable() {
             return;

--- a/src/game.rs
+++ b/src/game.rs
@@ -1058,9 +1058,6 @@ impl Game {
             if !self.get_creature(source).is_actionable() {
                 return;
             }
-            // calculate_damage applies Strength etc. and clamps to >= 0, so a
-            // negative pre-calc amount (e.g. Heavy Blade with negative Strength)
-            // is fine here.
             amount = self.calculate_damage(amount, source, target);
             if let Some(a) = self
                 .get_creature(target)


### PR DESCRIPTION
Heavy Blade folds Strength into the base damage it deals (14 + Strength*2, or *4 upgraded), which is negative when the player has sufficiently negative Strength (e.g. after Lagavulin's debuff). Game::damage asserted amount >= 0 at the top, before the Attack branch ran calculate_damage (which already clamps attack damage to >= 0), so playing Heavy Blade then panicked. Move the assert to after the Attack branch; non-attack damage is unchanged there and still guarded.