### PR TITLE
Stop Unceasing Top from spinning after combat ends

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -117,9 +117,6 @@ impl GameState for TestCombatStartGameState {
 
 fn unceasing_top_should_trigger(game: &Game) -> bool {
     game.in_combat != CombatType::None
-        // DrawAction is a no-op once combat is finished; without this guard the
-        // relic keeps requesting a draw that never lands, spinning forever with
-        // an empty hand after the last monster dies.
         && !game.combat_finished()
         && game.hand.is_empty()
         && game.has_relic(RelicClass::UnceasingTop)

--- a/src/game.rs
+++ b/src/game.rs
@@ -117,6 +117,10 @@ impl GameState for TestCombatStartGameState {
 
 fn unceasing_top_should_trigger(game: &Game) -> bool {
     game.in_combat != CombatType::None
+        // DrawAction is a no-op once combat is finished; without this guard the
+        // relic keeps requesting a draw that never lands, spinning forever with
+        // an empty hand after the last monster dies.
+        && !game.combat_finished()
         && game.hand.is_empty()
         && game.has_relic(RelicClass::UnceasingTop)
         && !game.player.has_status(Status::NoDraw)

--- a/src/relic.rs
+++ b/src/relic.rs
@@ -3428,8 +3428,6 @@ mod tests {
 
     #[test]
     fn test_unceasing_top_lethal_with_empty_hand() {
-        // Emptying the hand on the killing blow, with cards still in a pile,
-        // used to make Unceasing Top loop forever trying to redraw.
         let mut g = GameBuilder::default()
             .add_relic(RelicClass::UnceasingTop)
             .add_card(CardClass::DebugKillAll)

--- a/src/relic.rs
+++ b/src/relic.rs
@@ -3427,6 +3427,23 @@ mod tests {
     }
 
     #[test]
+    fn test_unceasing_top_lethal_with_empty_hand() {
+        // Emptying the hand on the killing blow, with cards still in a pile,
+        // used to make Unceasing Top loop forever trying to redraw.
+        let mut g = GameBuilder::default()
+            .add_relic(RelicClass::UnceasingTop)
+            .add_card(CardClass::DebugKillAll)
+            .build_combat();
+        g.add_card_to_discard_pile(CardClass::Strike);
+        g.step_test(PlayCardStep {
+            hand_index: 0,
+            target: None,
+        });
+        assert!(g.combat_finished());
+        assert!(g.hand.is_empty());
+    }
+
+    #[test]
     fn test_ssserpent_head() {
         let mut g = GameBuilder::default()
             .add_relic(RelicClass::SsserpentHead)


### PR DESCRIPTION
DrawAction is a no-op once combat_finished(), but unceasing_top_should_ trigger() did not check that. When the last monster dies with an empty hand and cards still in draw/discard, RunActionsGameState repeatedly re-queues a draw that DrawAction refuses, the hand stays empty, and the predicate stays true forever — an infinite action loop. Gate the relic trigger on !combat_finished() so it matches DrawAction.


(cherry picked from commit 280bc09d12a52e733c209c0048fdf1caaef5ffcc)