### PR TITLE
Fall back when the event pool is exhausted

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -40,6 +40,21 @@ impl GameState for RollEventGameState {
                 events = game.event_act_pool.clone();
             }
             events.retain(|e| e.can_spawn(game));
+            // A long climb can exhaust the chosen pool (each seen event is
+            // removed from every pool below), leaving nothing to sample. Fall
+            // back to whatever spawnable events remain across all pools so the
+            // room still resolves instead of panicking on an empty range.
+            if events.is_empty() {
+                events = game.event_act_pool.clone();
+                events.extend(game.event_shrine_pool.iter().copied());
+                events.extend(game.event_one_time_pool.iter().copied());
+                events.retain(|e| e.can_spawn(game));
+            }
+            // No spawnable event anywhere (pathological): resolve as an empty
+            // room rather than crash.
+            if events.is_empty() {
+                return;
+            }
             let e = remove_random(&mut game.rng, &mut events);
             game.event_act_pool.retain(|&e2| e2 != e);
             game.event_one_time_pool.retain(|&e2| e2 != e);

--- a/src/event.rs
+++ b/src/event.rs
@@ -40,18 +40,14 @@ impl GameState for RollEventGameState {
                 events = game.event_act_pool.clone();
             }
             events.retain(|e| e.can_spawn(game));
-            // A long climb can exhaust the chosen pool (each seen event is
-            // removed from every pool below), leaving nothing to sample. Fall
-            // back to whatever spawnable events remain across all pools so the
-            // room still resolves instead of panicking on an empty range.
+            // The chosen pool can be exhausted on a long climb; fall back to
+            // any spawnable event in the other pools.
             if events.is_empty() {
                 events = game.event_act_pool.clone();
                 events.extend(game.event_shrine_pool.iter().copied());
                 events.extend(game.event_one_time_pool.iter().copied());
                 events.retain(|e| e.can_spawn(game));
             }
-            // No spawnable event anywhere (pathological): resolve as an empty
-            // room rather than crash.
             if events.is_empty() {
                 return;
             }
@@ -142,6 +138,14 @@ mod tests {
         state::ContinueStep,
         step::Step,
     };
+
+    #[test]
+    fn test_event_pool_exhausted() {
+        // With every event pool empty, rolling an event must resolve the room
+        // rather than sample an empty range.
+        let g = GameBuilder::default().build_with_game_state(super::RollEventGameState);
+        assert!(g.cur_event.is_none());
+    }
 
     #[test]
     fn test_event_shop() {

--- a/src/event.rs
+++ b/src/event.rs
@@ -141,8 +141,6 @@ mod tests {
 
     #[test]
     fn test_event_pool_exhausted() {
-        // With every event pool empty, rolling an event must resolve the room
-        // rather than sample an empty range.
         let g = GameBuilder::default().build_with_game_state(super::RollEventGameState);
         assert!(g.cur_event.is_none());
     }


### PR DESCRIPTION
RollEventGameState picks an act/shrine/one-time event, then removes the chosen event from every pool. Over a long climb a pool can empty (or all remaining events fail can_spawn), so events is empty and remove_random samples 0..0 and panics ("cannot sample empty range"). Fall back to the spawnable events across all pools, and resolve the room as empty if none remain, so an event room never crashes the run.


(cherry picked from commit ca8ac77ae9cceb2a16ee896b4df4e0f70c2b5be8)


Note from Logikable: you probably don't need the second is_empty(). Claude added it to avoid a theoretical situation that could cause a panic.