### PR TITLE
Handle transforming zero cards without panicking

### DIFF
--- a/src/master_deck.rs
+++ b/src/master_deck.rs
@@ -96,7 +96,6 @@ pub struct TransformChosenCardsGameState {
 
 impl GameState for TransformChosenCardsGameState {
     fn run(&self, game: &mut Game) {
-        assert!(!game.chosen_cards.is_empty());
         while let Some(c) = game.chosen_cards.pop() {
             let class = c.borrow().class;
             let transformed = transformed(class, &mut game.rng);

--- a/src/relic.rs
+++ b/src/relic.rs
@@ -1355,6 +1355,20 @@ mod tests {
     }
 
     #[test]
+    fn test_astrolabe_with_no_transformable_cards_does_not_panic() {
+        let mut g = GameBuilder::default().build_shop();
+        g.run_action(GainRelicAction(RelicClass::Astrolabe));
+        assert!(g.has_relic(RelicClass::Astrolabe));
+    }
+
+    #[test]
+    fn test_pandoras_box_with_no_transformable_cards_does_not_panic() {
+        let mut g = GameBuilder::default().build_shop();
+        g.run_action(GainRelicAction(RelicClass::PandorasBox));
+        assert!(g.has_relic(RelicClass::PandorasBox));
+    }
+
+    #[test]
     fn test_burning_blood() {
         let mut g = GameBuilder::default()
             .add_card(CardClass::DebugKill)


### PR DESCRIPTION
Transforming a card set that turns out to be empty panicked on `assert!(!game.chosen_cards.is_empty())` in `TransformChosenCardsGameState`.

Two callers can reach it with nothing to transform when the master deck has no transformable cards:
- `ChooseTransformMasterGameState`'s auto-resolve path (e.g. Astrolabe transforming 3)
- `PandorasBoxGameState` (transforming all Strikes/Defends)

This is reachable now that boss relics are real (#7): a boss reward or Neow boss-relic swap can grant Astrolabe/Pandora's Box on a deck with no valid targets.

`RemoveChosenCardsGameState` already handles the empty case with no assert; this mirrors that — the transform becomes a no-op. Adds tests for both relics on an empty deck.