### PR TITLE
Add implemented events to the Act 1 event pool

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -305,6 +305,10 @@ impl GameState for EnterActGameState {
                 Event::Sssserpent,
                 Event::ShiningLight,
                 Event::LivingWall,
+                Event::DeadAdventurer,
+                Event::GoldenIdol,
+                Event::Mushrooms,
+                Event::ScrapOoze,
             ];
             game.easy_pool_combats = vec![
                 Combat::Cultist,


### PR DESCRIPTION
`DeadAdventurer`, `GoldenIdol`, `Mushrooms`, and `ScrapOoze` are implemented and tested, but they were not in any event pool, so they never spawned in a normal run. All four are Exordium (Act 1) events.

Added them to the Act 1 `event_act_pool`. The pool is sampled uniformly for ~75% of event rooms, so this just lets the existing implementations appear. Adds a test asserting the pool contains every implemented Act 1 event.